### PR TITLE
Generate static pages and host the redirects on GitHub Pages

### DIFF
--- a/.github/workflows/redirect.yml
+++ b/.github/workflows/redirect.yml
@@ -1,0 +1,45 @@
+# Simple workflow for deploying static content to GitHub Pages
+name: Deploy haunted-webring links redirects
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: ["main", "gh-pages"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  # Single deploy job since we're just deploying
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Generate Links
+        run: ruby redirect.rb
+        shell: bash
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          # Upload _pages directory
+          path: '_pages/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
-# haunted-webring
-a webring for ghosts
+# Haunted Webring
+
+A haunted webring. this repository implements a double-linked list that you can query.
+
+here is the full list of domains in the webring right now: https://github.com/VVX7/haunted-webring/blob/main/webring.txt
+
+usage
+usage: next | previous | random | list
+
+next
+GET /haunted-webring/pixeldreams.tokyo/next
+redirects to the site immediately BEFORE https://pixeldreams.tokyo/
+
+previous
+GET /haunted-webring/pixeldreams.tokyo/previous
+redirects to the site immediately AFTER https://pixeldreams.tokyo/
+
+random
+GET /haunted-webring/pixeldreams.tokyo/random
+redirects to a random site in the ring EXCEPT https://pixeldreams.tokyo/, it requires Javascript
+
+list
+GET /haunted-webring/list
+returns the hard-coded list of domains in the webring in text/plain
+
+html tag
+paste this into your html and modify how you like! (don't forget to edit the domain part)
+
+<p>
+  <a href='https://vvx7.github.io/haunted-webring/<your host>/previous'>&lt;&lt;&lt;</a>
+  this site is part of the <a href='https://vvx7.github.io/haunted-webring/README.md'>[haunted webring]</a> 
+  <a href='https://vvx7.github.io/haunted-webring/<your host>/next'>&gt;&gt;&gt;</a>
+</p>

--- a/redirect.rb
+++ b/redirect.rb
@@ -1,0 +1,79 @@
+require 'erb'
+require 'optparse'
+require 'ostruct'
+require 'csv'
+require 'fileutils'
+require 'uri'
+
+options = {
+  :output_dir => '_pages/',
+  :webring_file => 'webring.txt'
+}
+OptionParser.new do |opts|
+  opts.banner = "Usage: redirect.rb [options]"
+
+  opts.on("-v", "--[no-]verbose", "Run verbosely") do |v|
+    options[:verbose] = v
+  end
+
+  opts.on("-o", "--output-dir", "Output Directory") do |o|
+    options[:output_dir] = o
+  end
+
+  opts.on("-i", "--webring-file", "WebRing Links file") do |i|
+    options[:webring_file] = i
+  end
+end.parse!
+
+template = <<-EOF
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Redirecting to <%= link %></title>
+<meta http-equiv="refresh" content="0; URL=<%= link %>">
+<link rel="canonical" href="<%= link %>">
+EOF
+
+random_template = <<-EOF
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Random redirect for <%= link %></title>
+</head>
+<body>
+  <noscript>
+    Cannot random redirect! Enable Javascript!
+  </noscript>
+  <script>
+    let others = <%= others.to_s %>;
+    location.href = others[Math.floor(Math.random()*others.length)];
+  </script>
+</body>
+</html>
+EOF
+
+def render(t, vars)
+  ERB.new(t).result(OpenStruct.new(vars).instance_eval { binding })
+end
+
+class WrapArray < Array
+  def [](ind)
+    self.fetch(ind%self.length)
+  end
+end
+
+links = WrapArray.new CSV.readlines(options[:webring_file]).map(&:first)
+
+FileUtils.mkdir_p options[:output_dir]
+
+links.each_with_index do |l, idx|
+  host = URI.parse(l).host
+  FileUtils.mkdir_p "#{options[:output_dir]}/#{host}"
+  File.write("#{options[:output_dir]}/#{host}/next.html", render(template, link: links[idx+1]), mode: 'w+')
+  File.write("#{options[:output_dir]}/#{host}/previous.html", render(template, link: links[idx-1]), mode: 'w+')
+  File.write("#{options[:output_dir]}/#{host}/random.html", render(random_template, link: l, others: links - [l]), mode: 'w+')
+end
+
+File.write("#{options[:output_dir]}/list.html", render(template, link: "https://raw.githubusercontent.com/VVX7/haunted-webring/main/webring.txt"), mode: 'w+')
+FileUtils.cp('README.md', options[:output_dir])

--- a/redirect.rb
+++ b/redirect.rb
@@ -4,6 +4,7 @@ require 'ostruct'
 require 'csv'
 require 'fileutils'
 require 'uri'
+require 'open-uri'
 
 options = {
   :output_dir => '_pages/',
@@ -16,11 +17,11 @@ OptionParser.new do |opts|
     options[:verbose] = v
   end
 
-  opts.on("-o", "--output-dir", "Output Directory") do |o|
+  opts.on("-oDIR", "--output-dir=DIR", "Output Directory") do |o|
     options[:output_dir] = o
   end
 
-  opts.on("-i", "--webring-file", "WebRing Links file") do |i|
+  opts.on("-iFILE", "--webring-file=FILE", "WebRing Links file") do |i|
     options[:webring_file] = i
   end
 end.parse!
@@ -63,7 +64,7 @@ class WrapArray < Array
   end
 end
 
-links = WrapArray.new CSV.readlines(options[:webring_file]).map(&:first)
+links = WrapArray.new CSV.parse(URI.open(options[:webring_file]).read).map(&:first)
 
 FileUtils.mkdir_p options[:output_dir]
 


### PR DESCRIPTION
This will solve the SLA and location issues since it will be replicated along the globe in the GitHub CDN.

An example already working on my fork: https://thypon.github.io/haunted-webring/pompel.me/next

In the final version, the link should be as shown in the README.md

At the current stages it generates the following files in the `_pages` directory and uploads to the associated GitHub page:

```
$ tree _pages/
_pages/
├── README.md
├── ftp.lol
│   ├── next.html
│   ├── previous.html
│   └── random.html
├── h0wdy.partners
│   ├── next.html
│   ├── previous.html
│   └── random.html
├── hacking.rip
│   ├── next.html
│   ├── previous.html
│   └── random.html
├── list.html
├── malware.foundation
│   ├── next.html
│   ├── previous.html
│   └── random.html
├── mfavata.github.io
│   ├── next.html
│   ├── previous.html
│   └── random.html
├── nop.codes
│   ├── next.html
│   ├── previous.html
│   └── random.html
├── ortiz.sh
│   ├── next.html
│   ├── previous.html
│   └── random.html
├── paralys.is
│   ├── next.html
│   ├── previous.html
│   └── random.html
├── pixeldreams.tokyo
│   ├── next.html
│   ├── previous.html
│   └── random.html
├── pompel.me
│   ├── next.html
│   ├── previous.html
│   └── random.html
├── remyhax.xyz
│   ├── next.html
│   ├── previous.html
│   └── random.html
├── vvx7.io
│   ├── next.html
│   ├── previous.html
│   └── random.html
└── www.da.vidbuchanan.co.uk
    ├── next.html
    ├── previous.html
    └── random.html
```

Shortcomings, the random page is not static and requires javascript.